### PR TITLE
Issue #14: Remove image token generation

### DIFF
--- a/includes/image.inc
+++ b/includes/image.inc
@@ -60,10 +60,5 @@ function template_preprocess_image_insert_image(&$vars) {
   $absolute = isset($vars['widget']['settings']['insert_absolute']) ? $vars['widget']['settings']['insert_absolute'] : NULL;
   $vars['url'] = insert_create_url($vars['uri'], $absolute, variable_get('clean_url'));
 
-  if (function_exists('image_style_path_token')) {
-    $token_query = array(IMAGE_DERIVATIVE_TOKEN => image_style_path_token($vars['style_name'], $vars['file']->uri));
-    $vars['url'] .= (strpos($vars['url'], '?') !== FALSE ? '&' : '?') . backdrop_http_build_query($token_query);
-  }
-
   $vars['class'] = !empty($vars['widget']['settings']['insert_class']) ? $vars['widget']['settings']['insert_class'] : '';
 }


### PR DESCRIPTION
Image tokens were not implemented in Backdrop as they were in Drupal. Remove the code that attempted to add a token.